### PR TITLE
Had issues with Heroku app crashing, fixed bug

### DIFF
--- a/boneyardproj/settings.py
+++ b/boneyardproj/settings.py
@@ -12,8 +12,7 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 import os
 # import django_heroku
 from pathlib import Path
-from main_app.settings import SECRET_KEY
-from main_app.settings import KEY
+from decouple import config
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -24,7 +23,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = SECRET_KEY
+SECRET_KEY = config('SECRET_KEY')
+
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -118,7 +118,6 @@ USE_L10N = True
 
 USE_TZ = True
 
-KEY = KEY
 
 
 

--- a/main_app/services.py
+++ b/main_app/services.py
@@ -4,7 +4,7 @@ import json
 from decouple import config
 
 def get_parks(self, coordinates='', query=''):
-    API_KEY = os.environ.get('KEY')
+    API_KEY = config('KEY')
     radius = 2000
     endpoint_url = "https://maps.googleapis.com/maps/api/place/nearbysearch/json?fields=photos,formatted_address,name,rating,opening_hours,geometry&key=%s&keyword=dog+park&location=%s&radius=2000" % (API_KEY,coordinates)
 

--- a/main_app/services.py
+++ b/main_app/services.py
@@ -1,10 +1,10 @@
 from django.http import JsonResponse
 import requests
 import json
-from django.conf import settings
+from decouple import config
 
 def get_parks(self, coordinates='', query=''):
-    API_KEY = settings.KEY
+    API_KEY = os.environ.get('KEY')
     radius = 2000
     endpoint_url = "https://maps.googleapis.com/maps/api/place/nearbysearch/json?fields=photos,formatted_address,name,rating,opening_hours,geometry&key=%s&keyword=dog+park&location=%s&radius=2000" % (API_KEY,coordinates)
 


### PR DESCRIPTION
### Participating Group Members:
* Travis McKinstry 
* Roberto Rodriguez 
 
### Code Highlights:
   * Creates new way of grabbing environmental keys
 
### Have Tests Been Added?
- [x] No.
- [ ] Yes, but all tests are not passing. 
- [ ] Yes, and all are passing.
 
### Any background context you want to provide?

As mentioned in previous PR's related to this issue, the Heroku app was originally crashing because I listed the `settings.py` file in the `.gitignore`. This meant that when we pushed to GitHub (and eventually Heroku), neither had a `settings.py` file, causing the app to crash. I then un-ignored the `settings.py` file but was still left with the problem of having the API key and production key exposed.

I then tried to install python-decouple (`pip install python-decouple`) but the package wouldn't install. Eventually it did but the app was not recognizing the `from decouple import config` statement in the `settings.py` file. I then happened upon a command which successfully installed python-decouple: `python3 -m pip install python-decouple`. After that when I tried to run `python3 manage.py runserver`, there was no error but the keys were still exposed. I then added a `.env` file to the root directory (boneyard2) and inside that directory put: 'KEY = <api-key> \n 'SECRET_KEY=<secret-key>'.

Then in the `settings.py` file I had to format the key as so: `SECRET_KEY = config('SECRET_KEY')`. I then did the same for the API key in the file I was using it. I also had to add the import command to the file I was using the API key (`from decouple import config`). It is now working.

**NOTE:** one also must add the keys to their Heroku app via CLI or on the website.
 
### Message/Questions for reviewer:
 
### Issues: 
* Addresses # Heroku crashing
* Closes #
 
### Screenshots (if appropriate): 
*
 
### Tracking Consistency:
- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [x] I have added comments on my pull request, particularly in hard-to-understand areas
- [x] All new and existing tests passed

- [x] looked at PR preview to check spelling, syntax, formatting, and completion
