### PR TITLE
Installs new library for FE to access endpoint

### DIFF
--- a/boneyardproj/settings.py
+++ b/boneyardproj/settings.py
@@ -31,7 +31,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['boneyard-be.herokuapp.com', 'localhost']
 
-CORS_ALLOW_ALL_ORIGINS = True
+CORS_ORIGIN_ALLOW_ALL = True
 # Application definition
 
 INSTALLED_APPS = [

--- a/boneyardproj/settings.py
+++ b/boneyardproj/settings.py
@@ -31,7 +31,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['boneyard-be.herokuapp.com', 'localhost']
 
-
+CORS_ALLOW_ALL_ORIGINS = True
 # Application definition
 
 INSTALLED_APPS = [
@@ -41,12 +41,14 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'main_app.apps.MainAppConfig'
+    'main_app.apps.MainAppConfig',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/main_app/services.py
+++ b/main_app/services.py
@@ -22,7 +22,7 @@ def get_parks(self, coordinates=''):
 def format_data(info):
     parks = []
     for park in info['results']:
-        code.interact(local=dict(globals(), **locals()))
+        # code.interact(local=dict(globals(), **locals()))
         data = {
             'formatted_address': park['vicinity'],
             'geometry': park['geometry'],

--- a/main_app/services.py
+++ b/main_app/services.py
@@ -2,20 +2,27 @@ from django.http import JsonResponse
 import requests
 import json
 from decouple import config
+import code
+import re
 
 def get_parks(self, coordinates=''):
     KEY = config('KEY')
     radius = 2000
-    endpoint_url = "https://maps.googleapis.com/maps/api/place/nearbysearch/json?fields=photos,formatted_address,name,rating,opening_hours,geometry&key=%s&keyword=dog+park&location=%s&radius=2000" % (KEY,coordinates)
+    if len(coordinates.split(',')[0]) > 1 and float(coordinates.split(',')[0]):
+        endpoint_url = f"https://maps.googleapis.com/maps/api/place/nearbysearch/json?fields=photos,formatted_address,name,rating,opening_hours,geometry&key={KEY}&keyword=dog+park&location={coordinates}&radius=2000"
+        data = format_data(requests.get(endpoint_url).json())
+    elif re.match(r'^-?\d+(?:\.\d+)?$', coordinates.split(',')[0]) is None:
+        info = {'info': "geocode_api"}
+        data = format_directions(requests.get(endpoint_url).json())
+    else:
+        data = {'Error': "Input is incorrect. Please enter either coordinates as '132.5543,-204.5566' or 'city,state'"}
 
-    data = format_data(requests.get(endpoint_url).json())
-    # import code; code.interact(local=dict(globals(), **locals()))
     return JsonResponse(data, safe=False)
 
 def format_data(info):
     parks = []
     for park in info['results']:
-        # if 'opening_hours' in park:
+        code.interact(local=dict(globals(), **locals()))
         data = {
             'formatted_address': park['vicinity'],
             'geometry': park['geometry'],
@@ -25,3 +32,6 @@ def format_data(info):
             'rating': park['rating']}
         parks.append(data)
     return parks
+
+def format_directions(info):
+    'dude'

--- a/main_app/tests/test_app.py
+++ b/main_app/tests/test_app.py
@@ -16,6 +16,6 @@ class ApiTestCase(TestCase):
         """Can make an API call and expect specific attributes"""
         data = requests.get('https://jsonplaceholder.typicode.com/todos/1').json()
         # import code; code.interact(local=dict(globals(), **locals()))
-        self.assertEqual(str(type(data)), "<class 'dict'>")
+        self.assertEqual(type(data), dict)
         self.assertEqual(data['userId'], 1)
         self.assertEqual(str(data.keys()), "dict_keys(['userId', 'id', 'title', 'completed'])")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sqlparse==0.4.1
 whitenoise==5.2.0
 requests
 python-decouple==3.4
+django-cors-headers = "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ sqlparse==0.4.1
 whitenoise==5.2.0
 requests
 python-decouple==3.4
-django-cors-headers = "*"
+django-cors-headers


### PR DESCRIPTION
### Participating Group Members:
* Travis McKinstry 

 
### Have Tests Been Added?
- [x] No.
- [ ] Yes, but all tests are not passing. 
- [ ] Yes, and all are passing.
 
### Any background context you want to provide?

FE wasn't able to access the BE endpoint with the Heroku URL. Long story short; BE had to install a 'cors-headers' library to allow "cross origin access"-- essentially to allow 'localhost' to access the Heroku-app endpoint.
 
### Message/Questions for reviewer:
 
### Issues: 
* Addresses # FE not being able to access endpoint

 
### Tracking Consistency:
- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [x] I have added comments on my pull request, particularly in hard-to-understand areas
- [x] All new and existing tests passed

- [x] looked at PR preview to check spelling, syntax, formatting, and completion
