### PR TITLE
Add sad path for incorrect input format

### DIFF
--- a/main_app/tests/test_app.py
+++ b/main_app/tests/test_app.py
@@ -19,3 +19,10 @@ class ApiTestCase(TestCase):
         self.assertEqual(type(data), dict)
         self.assertEqual(data['userId'], 1)
         self.assertEqual(str(data.keys()), "dict_keys(['userId', 'id', 'title', 'completed'])")
+
+    def test_can_return_error(self):
+        """Can return an error when entering incorrect coordinate format"""
+        data = requests.get('https://jsonplaceholder.typicode.com/todos/1').json()
+        self.assertEqual(type(data), dict)
+        self.assertEqual(data['userId'], 1)
+            self.assertEqual(str(data.keys()), 'Error': "Input is incorrect. Please enter either coordinates as '132.5543,-204.5566' or 'city,state'")


### PR DESCRIPTION
### Participating Group Members:
* Judith Pillado 
 
### Code Highlights:
   * Sad path testing 
   
### Have Tests Been Added?
- [ ] No.
- [X] Yes, but all tests are not passing. 
- [ ] Yes, and all are passing.
 
### Any background context you want to provide?
 I wanted to test the sad path that was created in the `services.py` file for `get_parks` method. 

### Message/Questions for reviewer:
Not sure this is working properly ☹️
 
### Issues: 
* Addresses #29 
* Closes #
 
### Screenshots (if appropriate): 
*
 
### Tracking Consistency:
- [x] added appropriate labels
- [ ] My code follows the code style of this project and has removed all unnecessary annotations
- [ ] I have added comments on my pull request, particularly in hard-to-understand areas
- [ ] All new and existing tests passed

- [x] looked at PR preview to check spelling, syntax, formatting, and completion
