### PR TITLE
Fixes Heroku app crashing

### DIFF
--- a/main_app/models.py
+++ b/main_app/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+import code
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, \
                                         PermissionsMixin
 class Park(models.Model):
@@ -11,10 +12,12 @@ class Park(models.Model):
 
 
 def create_park(self, name, formatted_address, opening_hours, photo, rating, **extra_fields):
+    code.interact(local=dict(globals(), **locals()))
     park = self.model(name=self.name, formatted_address=self.formatted_address, opening_hours=self.opening_hours, photo=self.photo, rating=self.rating)
     park.save(using=self._db)
 
     return park
+
 class UserManager(BaseUserManager):
 
     def create_user(self, email, **extra_fields):

--- a/main_app/services.py
+++ b/main_app/services.py
@@ -5,6 +5,8 @@ from decouple import config
 import code
 import re
 from main_app.serializer import Serializer
+from main_app.models import Park
+from django.http import HttpResponse
 
 class Services:
 
@@ -41,3 +43,17 @@ class Services:
     @staticmethod
     def format_directions(info):
         'dude'
+
+    @staticmethod
+    def get_all_parks(self):
+        info = Park.objects.all()
+        parks = []
+        for park in info:
+            data = {
+                'name': park.name,
+                'address': park.formatted_address,
+                'opening_hours': park.opening_hours,
+                'photos': park.photo,
+                'rating': park.rating}
+            parks.append(data)
+        return HttpResponse(parks, content_type='json')

--- a/main_app/tests/test_app.py
+++ b/main_app/tests/test_app.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 import requests
 import code
 from main_app import services
-from rest_framework.test import APIRequestFactory
 import json
 
 

--- a/main_app/tests/test_app.py
+++ b/main_app/tests/test_app.py
@@ -2,6 +2,8 @@ from django.test import TestCase
 import requests
 import code
 from main_app import services
+from rest_framework.test import APIRequestFactory
+import json
 
 
 class ApiTestCase(TestCase):
@@ -44,3 +46,17 @@ class ApiTestCase(TestCase):
         self.assertIn('opening_hours', data[0])
         self.assertIn('photos', data[0])
         self.assertIn('rating', data[0])
+
+    def test_can_make_map_API_call_and_save_a_park(self):
+        """Can make an API call and expect specific attributes (run local server first)"""
+        params = {
+        "name": "Fake Park",
+        "formatted_address": "1234 Fake Street",
+        "opening_hours": "never",
+        "photo": "too good for photos",
+        "rating": "100 mofo"
+        }
+        data = requests.post('http://localhost:8000/api/park/create/', params)
+        self.assertEqual(type(data), requests.models.Response)
+
+        result = requests.get('http://localhost:8000/api/park/all')

--- a/main_app/tests/test_models.py
+++ b/main_app/tests/test_models.py
@@ -3,7 +3,6 @@ from django.contrib.auth import get_user_model
 from main_app.models import Park
 
 class ModelTests(TestCase):
-#Trying to get this test to pass. Getting error 'unexpected keyword argument 'photo''
     def test_create_park_with_name_and_address(self):
         """Test creating a new park with name and address"""
         name = 'park'

--- a/park/urls.py
+++ b/park/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
 from park import views
+from main_app.services import Services
 
 app_name = 'park'
 
 urlpatterns = [
     path('create/', views.CreateParkView.as_view(), name='create'),
+    path('all/', Services.get_all_parks)
 ]

--- a/park/views.py
+++ b/park/views.py
@@ -1,8 +1,8 @@
 from rest_framework import generics
 from park.serializers import ParkSerializer
+from main_app.models import Park
 
 
 class CreateParkView(generics.CreateAPIView):
     """Create a new user in the system"""
     serializer_class = ParkSerializer
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ whitenoise==5.2.0
 requests
 python-decouple==3.4
 django-cors-headers
+djangorestframework


### PR DESCRIPTION
### Participating Group Members:
* Travis McKinstry 
 
### Code Highlights:
   * Adds `djangorestframework` to `requirements.txt` file
 
### Have Tests Been Added?
- [ ] No.
- [ ] Yes, but all tests are not passing. 
- [ ] Yes, and all are passing.
 
### Any background context you want to provide?
 
FE said they weren't getting parks back like they were able to before. Turns out the app was crashing cause we didn't include new dependencies in the `requirements.txt` file

 
### Tracking Consistency:
- [x] added appropriate labels
- [x] My code follows the code style of this project and has removed all unnecessary annotations
- [x] I have added comments on my pull request, particularly in hard-to-understand areas
- [x] All new and existing tests passed

- [x] looked at PR preview to check spelling, syntax, formatting, and completion
